### PR TITLE
chore: remove version field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "static-site-boilerplate-vite",
-  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove the unused `version` field from package.json since this is a private project

## Test plan
- [x] Verify package.json is still valid
- [x] Confirm no scripts or tooling rely on the version field

🤖 Generated with [Claude Code](https://claude.com/claude-code)