### PR TITLE
chore(css): clarify Chrome image-rendering comment

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -53,11 +53,10 @@ dialog {
   }
 }
 
-/* stylelint-disable */
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  /* for Google Chrome */
+  /* Sharpen downscaled images in Chrome, which otherwise blurs them. */
   img {
     image-rendering: -webkit-optimize-contrast;
   }
 }
-/* stylelint-enable */


### PR DESCRIPTION
## Summary
- Reworded the terse `/* for Google Chrome */` comment to explain that the rule sharpens downscaled images Chrome would otherwise blur.
- Narrowed the broad `stylelint-disable` / `stylelint-enable` block to a targeted `stylelint-disable-next-line media-feature-name-no-vendor-prefix`.

## Test plan
- Comment and lint-scope change only; no visual or behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)