### PR TITLE
refactor: move eslintConfigPrettier to end of config array

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,6 @@ export default [
     ignores: ["dist/**"],
   },
   js.configs.recommended,
-  eslintConfigPrettier,
   {
     languageOptions: {
       ecmaVersion: "latest",
@@ -26,4 +25,5 @@ export default [
       "simple-import-sort/exports": "error",
     },
   },
+  eslintConfigPrettier,
 ];


### PR DESCRIPTION
## Overview

Moved `eslintConfigPrettier` to the end of the config array (after the `simple-import-sort` config block).

## Reason

`eslint-config-prettier` exists to disable the formatting-related rules enabled by preceding configs, so the [official docs](https://github.com/prettier/eslint-config-prettier#installation) recommend placing it last.

The custom `simple-import-sort` rules are not formatting-related, so the actual behavior is unchanged, but this matches the recommended ordering and makes the intent clear.

## Verification

- Confirmed `npx eslint .` loads correctly (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)